### PR TITLE
fix(TabInstance): change to setFooter on TabInstance contrutor.

### DIFF
--- a/src/main/java/dev/gump/mars/tab/TabInstance.java
+++ b/src/main/java/dev/gump/mars/tab/TabInstance.java
@@ -10,7 +10,7 @@ public class TabInstance {
     String header, footer;
     public TabInstance(String header, String footer){
         setHeader(header);
-        setHeader(footer);
+        setFooter(footer);
     }
 
     public List<String> getHeaderList(){


### PR DESCRIPTION
footer was being placed as header.

`dev.gump.mars.tab.TabInstance.java`
```diff
public TabInstance(String header, String footer) {
    setHeader(header);
--  setHeader(footer);
++  setFooter(footer);
}
```