### PR TITLE
fix(TabInstance): double campare header length on render function.

### DIFF
--- a/src/main/java/dev/gump/mars/tab/TabInstance.java
+++ b/src/main/java/dev/gump/mars/tab/TabInstance.java
@@ -34,7 +34,7 @@ public class TabInstance {
     }
 
     public void render(Player player){
-        if(getHeader().length() > 0 && getHeader().length() > 0)
+        if(getHeader().length() > 0 && getFooter().length() > 0)
             player.setPlayerListHeaderFooter(getHeader(),getFooter());
         else if(getHeader().length() > 0)
             player.setPlayerListHeader(getFooter());


### PR DESCRIPTION
render double compare header length instead of footer.

`dev.gump.mars.tab.TabInstance.java`
```diff
...
public void render(Player player){
--  if(getHeader().length() > 0 && getHeader().length() > 0)
++  if(getHeader().length() > 0 && getFooter().length() > 0)
        player.setPlayerListHeaderFooter(getHeader(),getFooter());
    else if(getHeader().length() > 0)
        player.setPlayerListHeader(getFooter());
    else if(getFooter().length() > 0)
        player.setPlayerListHeader(getFooter());
}
...
```